### PR TITLE
Add demo scripts and artifacts

### DIFF
--- a/hack/demo/foo-gateway.yaml
+++ b/hack/demo/foo-gateway.yaml
@@ -1,0 +1,18 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: foo-gateway
+  namespace: foo-infra
+spec:
+  gatewayClassName: aws-alb-crossplane-public
+  listeners:
+  - name: web
+    port: 80
+    protocol: HTTP
+    hostname: "foo.example.com"
+    allowedRoutes:
+      namespaces:
+        from: Selector
+        selector:
+          matchLabels:
+            allowGateway: foo

--- a/hack/demo/foo-namespaces.yaml
+++ b/hack/demo/foo-namespaces.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: foo-infra
+  labels:
+    istio.io/rev: 1-16-1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: foo-site
+  labels:
+    allowGateway: foo
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: foo-store
+  labels:
+    allowGateway: foo

--- a/hack/demo/gatewayclass-aws-alb-crossplane.yaml
+++ b/hack/demo/gatewayclass-aws-alb-crossplane.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aws-alb-crossplane-public
 spec:
   controllerName: "github.com/tv2-oss/gateway-controller"
-  description: "Internet-facing AWS ALB load balancer and Istio ingress gateway"
+  description: "Internet-facing AWS ALB and Istio ingress gateway"
   parametersRef:
     group: gateway.tv2.dk
     kind: GatewayClassBlueprint
@@ -16,7 +16,7 @@ metadata:
   name: aws-alb-crossplane-internal
 spec:
   controllerName: "github.com/tv2-oss/gateway-controller"
-  description: "Internal AWS ALB load balancer and Istio ingress gateway"
+  description: "Internal AWS ALB and Istio ingress gateway"
   parametersRef:
     group: gateway.tv2.dk
     kind: GatewayClassBlueprint

--- a/hack/demo/gatewayclass-aws-alb-crossplane.yaml
+++ b/hack/demo/gatewayclass-aws-alb-crossplane.yaml
@@ -1,0 +1,23 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: GatewayClass
+metadata:
+  name: aws-alb-crossplane-public
+spec:
+  controllerName: "github.com/tv2-oss/gateway-controller"
+  description: "Internet-facing AWS ALB load balancer and Istio ingress gateway"
+  parametersRef:
+    group: gateway.tv2.dk
+    kind: GatewayClassBlueprint
+    name: aws-alb-crossplane
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: GatewayClass
+metadata:
+  name: aws-alb-crossplane-internal
+spec:
+  controllerName: "github.com/tv2-oss/gateway-controller"
+  description: "Internal AWS ALB load balancer and Istio ingress gateway"
+  parametersRef:
+    group: gateway.tv2.dk
+    kind: GatewayClassBlueprint
+    name: aws-alb-crossplane

--- a/hack/demo/gatewayclassblueprint-aws-alb-crossplane.yaml
+++ b/hack/demo/gatewayclassblueprint-aws-alb-crossplane.yaml
@@ -1,0 +1,268 @@
+apiVersion: gateway.tv2.dk/v1alpha1
+kind: GatewayClassBlueprint
+metadata:
+  name: aws-alb-crossplane
+spec:
+  values:
+    default:
+      healthCheck:
+        interval: 5
+        timeout: 4
+        threshold: 2
+        path: /healthz/ready
+        port: 15021
+      ingressAcls:
+        cidrs:
+        - 0.0.0.0/0
+        port: 80
+    # Values required by this blueprint without defaults:
+    #   region: "example-region"
+    #   vpcId:  "example-vpc"
+    #   subnets:
+    #   - "example-subnet1"
+    #   - "example-subnet2"
+    #   - "example-subnet3"
+    #   upstreamSecurityGroup: "example-cluster-sg"
+
+  # The following are templates used to 'implement' a 'parent' Gateway
+  gatewayTemplate:
+    status:
+      template: |
+        addresses:
+        - type: Hostname
+          value: {{ .Resources.LB.status.atProvider.dnsName }}
+    resourceTemplates:
+      childGateway: |
+        apiVersion: gateway.networking.k8s.io/v1beta1
+        kind: Gateway
+        metadata:
+          name: {{ .Gateway.metadata.name }}-child
+          namespace: {{ .Gateway.metadata.namespace }}
+          annotations:
+            networking.istio.io/service-type: ClusterIP
+        spec:
+          gatewayClassName: istio
+          listeners:
+            {{- toYaml .Gateway.spec.listeners | nindent 6 }}
+      LB: |
+        apiVersion: elbv2.aws.upbound.io/v1beta1
+        kind: LB
+        metadata:
+          labels:
+            tv2.dk/gw: {{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
+          name: gw-{{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
+        spec:
+          providerConfigRef:
+            name: admin
+          forProvider:
+            name: gw-{{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
+            region: {{ .Values.region }}
+            securityGroupSelector:
+              matchLabels:
+                tv2.dk/gw: {{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
+            subnetMapping:
+              {{ range .Values.subnets }}
+              - subnetId: {{ . }}
+              {{ end }}
+      LBTargetGroup: |
+        apiVersion: elbv2.aws.upbound.io/v1beta1
+        kind: LBTargetGroup
+        metadata:
+          labels:
+            tv2.dk/gw: {{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
+          name: gw-{{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
+        spec:
+          providerConfigRef:
+            name: admin
+          forProvider:
+            name: gw-{{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
+            region: {{ .Values.region }}
+            vpcId: {{ .Values.vpcId }}
+            healthCheck:
+            - enabled: true
+              healthyThreshold: {{ .Values.healthCheck.threshold }}
+              interval: {{ .Values.healthCheck.interval }}
+              timeout: {{ .Values.healthCheck.timeout }}
+              path: {{ .Values.healthCheck.path }}
+              port: {{ .Values.healthCheck.port | quote }}
+            port: 80
+            protocol: HTTP
+            targetType: ip
+      LBListener: |
+        apiVersion: elbv2.aws.upbound.io/v1beta1
+        kind: LBListener
+        metadata:
+          labels:
+            tv2.dk/gw: {{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
+          name: gw-{{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
+        spec:
+          providerConfigRef:
+            name: admin
+          forProvider:
+            region: {{ .Values.region }}
+            port: 80
+            protocol: HTTP
+            defaultAction:
+            - targetGroupArnSelector:
+                matchLabels:
+                  tv2.dk/gw: {{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
+              type: forward
+            loadBalancerArnSelector:
+              matchLabels:
+                tv2.dk/gw: {{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
+      TargetGroupBinding: |
+        apiVersion: elbv2.k8s.aws/v1beta1
+        kind: TargetGroupBinding
+        metadata:
+          name: gw-{{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
+          namespace: {{ .Gateway.metadata.namespace }}
+        spec:
+          targetGroupARN: {{ .Resources.LBTargetGroup.status.atProvider.arn }}
+          targetType: ip
+          serviceRef:
+            name: {{ .Gateway.metadata.name }}-child
+            port: 80
+      SecurityGroup: |
+        apiVersion: ec2.aws.upbound.io/v1beta1
+        kind: SecurityGroup
+        metadata:
+          labels:
+            tv2.dk/gw: {{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
+          name: gw-{{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
+        spec:
+          providerConfigRef:
+            name: admin
+          forProvider:
+            description: "SG for ALB"
+            region: {{ .Values.region }}
+            vpcId: {{ .Values.vpcId}}
+            name: gw-{{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
+      SecurityGroupRuleEgress80: |
+        apiVersion: ec2.aws.upbound.io/v1beta1
+        kind: SecurityGroupRule
+        metadata:
+          labels:
+            tv2.dk/gw: {{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
+          name: gw-{{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}-egress80
+        spec:
+          providerConfigRef:
+            name: admin
+          forProvider:
+            cidrBlocks:
+              - 0.0.0.0/0
+            fromPort: 80
+            protocol: tcp
+            region: {{ .Values.region }}
+            securityGroupIdSelector:
+              matchLabels:
+                tv2.dk/gw: {{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
+            toPort: 80
+            type: egress
+      SecurityGroupRuleEgress15021: |
+        apiVersion: ec2.aws.upbound.io/v1beta1
+        kind: SecurityGroupRule
+        metadata:
+          labels:
+            tv2.dk/gw: {{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
+          name: gw-{{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}-egress15021
+        spec:
+          providerConfigRef:
+            name: admin
+          forProvider:
+            description: "Healthcheck towards Istio ingress gateway"
+            cidrBlocks:
+              - 0.0.0.0/0
+            fromPort: 15021
+            protocol: tcp
+            region: {{ .Values.region }}
+            securityGroupIdSelector:
+              matchLabels:
+                tv2.dk/gw: {{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
+            toPort: 15021
+            type: egress
+      SecurityGroupRuleIngress: |
+        apiVersion: ec2.aws.upbound.io/v1beta1
+        kind: SecurityGroupRule
+        metadata:
+          labels:
+            tv2.dk/gw: {{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
+          name: gw-{{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}-ingress
+        spec:
+          providerConfigRef:
+            name: admin
+          forProvider:
+            cidrBlocks:
+              {{ range .Values.ingressAcls.cidrs -}}
+              - {{ . }}
+              {{- end }}
+            fromPort: {{ .Values.ingressAcls.port }}
+            protocol: tcp
+            region: {{ .Values.region }}
+            securityGroupIdSelector:
+              matchLabels:
+                tv2.dk/gw: {{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
+            toPort: {{ .Values.ingressAcls.port }}
+            type: ingress
+      SecurityGroupRuleUpstreamIngress80: |
+        apiVersion: ec2.aws.upbound.io/v1beta1
+        kind: SecurityGroupRule
+        metadata:
+          labels:
+            tv2.dk/gw: {{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
+          name: gw-{{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}-upstream80
+        spec:
+          providerConfigRef:
+            name: admin
+          forProvider:
+            description: {{ printf "Ingress from gw-%s-%s" .Gateway.metadata.namespace .Gateway.metadata.name }}
+            fromPort: 80
+            protocol: tcp
+            region: {{ .Values.region }}
+            securityGroupId: {{ .Values.upstreamSecurityGroup }}
+            sourceSecurityGroupIdSelector:
+              matchLabels:
+                tv2.dk/gw: {{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
+            toPort: 80
+            type: ingress
+      SecurityGroupRuleUpstreamIngress15021: |
+        apiVersion: ec2.aws.upbound.io/v1beta1
+        kind: SecurityGroupRule
+        metadata:
+          labels:
+            tv2.dk/gw: {{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
+          name: gw-{{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}-upstream15021
+        spec:
+          providerConfigRef:
+            name: admin
+          forProvider:
+            description: {{ printf "Healthcheck ingress from gw-%s-%s" .Gateway.metadata.namespace .Gateway.metadata.name }}
+            fromPort: 15021
+            protocol: tcp
+            region: {{ .Values.region }}
+            securityGroupId: {{ .Values.upstreamSecurityGroup }}
+            sourceSecurityGroupIdSelector:
+              matchLabels:
+                tv2.dk/gw: {{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
+            toPort: 15021
+            type: ingress
+
+  # The following are templates used to 'implement' a 'parent' HTTPRoute
+  httpRouteTemplate:
+    resourceTemplates:
+      childHttproute: |
+        apiVersion: gateway.networking.k8s.io/v1beta1
+        kind: HTTPRoute
+        metadata:
+          name: {{ .HTTPRoute.metadata.name }}-child
+          namespace: {{ .HTTPRoute.metadata.namespace }}
+        spec:
+          parentRefs:
+          {{ range .HTTPRoute.spec.parentRefs -}}
+          - kind: {{ .kind }}
+            name: {{ .name }}-child
+            {{ if get . "namespace" }}
+            namespace: {{ .namespace }}
+            {{ end -}}
+          {{ end }}
+          rules:
+            {{- toYaml .HTTPRoute.spec.rules | nindent 4 }}

--- a/hack/demo/gatewayclassblueprint-aws-alb-crossplane.yaml
+++ b/hack/demo/gatewayclassblueprint-aws-alb-crossplane.yaml
@@ -14,7 +14,7 @@ spec:
       ingressAcls:
         cidrs:
         - 0.0.0.0/0
-        port: 80
+        port: 443
     # Values required by this blueprint without defaults:
     #   region: "example-region"
     #   vpcId:  "example-vpc"
@@ -23,6 +23,7 @@ spec:
     #   - "example-subnet2"
     #   - "example-subnet3"
     #   upstreamSecurityGroup: "example-cluster-sg"
+    #   certificateArn: "example-cert-arn"
 
   # The following are templates used to 'implement' a 'parent' Gateway
   gatewayTemplate:
@@ -43,7 +44,14 @@ spec:
         spec:
           gatewayClassName: istio
           listeners:
-            {{- toYaml .Gateway.spec.listeners | nindent 6 }}
+          {{- range .Gateway.spec.listeners }}
+          - name: {{ .name }}
+            port: 80
+            protocol: HTTP
+            {{ if get . "hostname" }}
+            hostname: {{ .hostname | quote }}
+            {{ end -}}
+          {{- end }}
       LB: |
         apiVersion: elbv2.aws.upbound.io/v1beta1
         kind: LB
@@ -57,6 +65,7 @@ spec:
           forProvider:
             name: gw-{{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
             region: {{ .Values.region }}
+            internal: {{ .Values.internal }}
             securityGroupSelector:
               matchLabels:
                 tv2.dk/gw: {{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
@@ -100,8 +109,9 @@ spec:
             name: admin
           forProvider:
             region: {{ .Values.region }}
-            port: 80
-            protocol: HTTP
+            port: 443
+            protocol: HTTPS
+            certificateArn: {{ .Values.certificateArn }}
             defaultAction:
             - targetGroupArnSelector:
                 matchLabels:
@@ -148,6 +158,7 @@ spec:
           providerConfigRef:
             name: admin
           forProvider:
+            description: "Traffic towards Istio ingress gateway"
             cidrBlocks:
               - 0.0.0.0/0
             fromPort: 80
@@ -191,6 +202,7 @@ spec:
           providerConfigRef:
             name: admin
           forProvider:
+            description: "External traffic towards ALB"
             cidrBlocks:
               {{ range .Values.ingressAcls.cidrs -}}
               - {{ . }}

--- a/hack/demo/gatewayclassconfig-aws-alb-crossplane-dev-env.yaml
+++ b/hack/demo/gatewayclassconfig-aws-alb-crossplane-dev-env.yaml
@@ -12,6 +12,7 @@ spec:
     - subnet-0844755379de6d6f8
     - subnet-0e6f13b058d3c3729
     upstreamSecurityGroup: sg-0c5b5ae07d31da906
+    internal: false
   targetRef:
     group: gateway.networking.k8s.io
     kind: GatewayClass
@@ -31,6 +32,7 @@ spec:
     - subnet-094508a77cf895ec9
     - subnet-099f1b955e66e1a4a
     upstreamSecurityGroup: sg-0c5b5ae07d31da906
+    internal: true
   targetRef:
     group: gateway.networking.k8s.io
     kind: GatewayClass

--- a/hack/demo/gatewayclassconfig-aws-alb-crossplane-dev-env.yaml
+++ b/hack/demo/gatewayclassconfig-aws-alb-crossplane-dev-env.yaml
@@ -1,0 +1,37 @@
+apiVersion: gateway.tv2.dk/v1alpha1
+kind: GatewayClassConfig
+metadata:
+  name: aws-alb-crossplane-public-dev-env
+  namespace: gateway-controller-system
+spec:
+  override:
+    region: eu-central-1
+    vpcId: vpc-0e4501e0fbc404284
+    subnets:
+    - subnet-03b44b0d7d83febbc
+    - subnet-0844755379de6d6f8
+    - subnet-0e6f13b058d3c3729
+    upstreamSecurityGroup: sg-0c5b5ae07d31da906
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: GatewayClass
+    name: aws-alb-crossplane-public
+---
+apiVersion: gateway.tv2.dk/v1alpha1
+kind: GatewayClassConfig
+metadata:
+  name: aws-alb-crossplane-internal-dev-env
+  namespace: gateway-controller-system
+spec:
+  override:
+    region: eu-central-1
+    vpcId: vpc-0e4501e0fbc404284
+    subnets:
+    - subnet-045141a3fdf9d7bb9
+    - subnet-094508a77cf895ec9
+    - subnet-099f1b955e66e1a4a
+    upstreamSecurityGroup: sg-0c5b5ae07d31da906
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: GatewayClass
+    name: aws-alb-crossplane-internal

--- a/hack/demo/test-add-user-acl.sh
+++ b/hack/demo/test-add-user-acl.sh
@@ -1,0 +1,15 @@
+#! /bin/bash
+
+MYIP=`curl -s ifconfig.me`
+
+echo "************************"
+echo "Using local IP: $MYIP"
+echo "************************"
+echo ""
+
+cat hack/demo/user-gateway-acl.yaml | sed -e "s/1.2.3.4/$MYIP/"
+
+echo ""
+read -p "Press enter to deploy GatewayConfig"
+
+cat hack/demo/user-gateway-acl.yaml | sed -e "s/1.2.3.4/$MYIP/" | kubectl apply -f -

--- a/hack/demo/test-curl.sh
+++ b/hack/demo/test-curl.sh
@@ -3,9 +3,18 @@
 ADDR=`kubectl -n foo-infra get gateway foo-gateway -o jsonpath='{.status.addresses[0].value}'`
 IP=`dig "$ADDR" +short | head -n1`
 
+echo "-------------------------------------------------------------------"
+echo "Skipping DNS, using $ADDR = $IP"
+echo "-------------------------------------------------------------------"
+read -p "Press enter to run CURL commands"
+
+echo "-------------------------------------------------------------------"
+echo ""
 echo "1x curl http://foo.example.com/site"
 curl --resolve foo.example.com:80:$IP http://foo.example.com/site
 
+echo "-------------------------------------------------------------------"
+echo ""
 echo "20x curl http://foo.example.com/store"
 for i in {1..20}
 do

--- a/hack/demo/test-delete.sh
+++ b/hack/demo/test-delete.sh
@@ -1,0 +1,23 @@
+#! /bin/bash
+
+set -x
+
+#kubectl delete -n foo-infra gateway foo-gateway
+#kubectl delete -n foo-site httproute foo-site
+#kubectl delete -n foo-store httproute foo-store
+kubectl delete -f test-data/getting-started/foo-namespaces.yaml
+
+kubectl delete securitygrouprule.ec2.aws.upbound.io/gw-foo-infra-foo-gateway-upstream15021
+kubectl delete securitygrouprule.ec2.aws.upbound.io/gw-foo-infra-foo-gateway-upstream80
+kubectl delete securitygrouprule.ec2.aws.upbound.io/gw-foo-infra-foo-gateway-egress15021
+kubectl delete securitygrouprule.ec2.aws.upbound.io/gw-foo-infra-foo-gateway-egress80
+kubectl delete securitygrouprule.ec2.aws.upbound.io/gw-foo-infra-foo-gateway-ingress
+kubectl delete lblistener.elbv2.aws.upbound.io/gw-foo-infra-foo-gateway
+kubectl delete lbtargetgroup.elbv2.aws.upbound.io/gw-foo-infra-foo-gateway
+kubectl delete lb.elbv2.aws.upbound.io/gw-foo-infra-foo-gateway
+kubectl delete securitygroup.ec2.aws.upbound.io/gw-foo-infra-foo-gateway
+kubectl delete -n foo-infra targetgroupbinding.elbv2.k8s.aws/gw-foo-infra-foo-gateway
+
+kubectl delete -f test-data/gatewayclassconfig-aws-alb-crossplane-dev-env.yaml
+kubectl delete -f test-data/gatewayclassblueprint-aws-alb-crossplane.yaml
+kubectl delete -f test-data/gatewayclass-aws-alb-crossplane.yaml

--- a/hack/demo/test-setup.sh
+++ b/hack/demo/test-setup.sh
@@ -3,13 +3,13 @@
 echo ""
 echo "-------------------------------------------------------------------"
 read -p "Press enter to deploy GatewayClassBlueprint + GatewayClass'es"
-kubectl apply -f test-data/gatewayclassblueprint-aws-alb-crossplane.yaml
-kubectl apply -f test-data/gatewayclass-aws-alb-crossplane.yaml
+kubectl apply -f hack/demo/gatewayclassblueprint-aws-alb-crossplane.yaml
+kubectl apply -f hack/demo/gatewayclass-aws-alb-crossplane.yaml
 
 echo ""
 echo "-------------------------------------------------------------------"
 read -p "Press enter to deploy GatewayClassConfig's"
-kubectl apply -f test-data/gatewayclassconfig-aws-alb-crossplane-dev-env.yaml
+kubectl apply -f hack/demo/gatewayclassconfig-aws-alb-crossplane-dev-env.yaml
 
 echo ""
 echo "-------------------------------------------------------------------"

--- a/hack/demo/test-setup.sh
+++ b/hack/demo/test-setup.sh
@@ -14,4 +14,14 @@ kubectl apply -f test-data/gatewayclassconfig-aws-alb-crossplane-dev-env.yaml
 echo ""
 echo "-------------------------------------------------------------------"
 read -p "Press enter to deploy getting-started usecase"
-make setup-getting-started-usecase
+kubectl -n foo-infra apply -f hack/demo/foo-namespaces.yaml -f hack/demo/foo-gateway.yaml
+kubectl -n foo-site apply -f test-data/getting-started/app-foo-site.yaml
+kubectl -n foo-site  apply -f test-data/getting-started/foo-site-httproute.yaml
+kubectl -n foo-store apply -f test-data/getting-started/app-foo-store-v1.yaml
+kubectl -n foo-store apply -f test-data/getting-started/app-foo-store-v2.yaml
+kubectl -n foo-store apply -f test-data/getting-started/foo-store-httproute.yaml
+
+echo ""
+echo "-------------------------------------------------------------------"
+read -p "Press enter to show user GatewayConfig with ACL CIDR"
+hack/demo/test-add-user-acl.sh

--- a/hack/demo/user-gateway-acl.yaml
+++ b/hack/demo/user-gateway-acl.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.tv2.dk/v1alpha1
+kind: GatewayConfig
+metadata:
+  name: foo-gateway-custom-acl
+  namespace: foo-infra
+spec:
+  override:
+    ingressAcls:
+      cidrs:
+      - 1.2.3.4/32
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: foo-gateway
+    namespace: foo-infra

--- a/test-data/gatewayclassblueprint-aws-alb-crossplane.yaml
+++ b/test-data/gatewayclassblueprint-aws-alb-crossplane.yaml
@@ -14,7 +14,7 @@ spec:
       ingressAcls:
         cidrs:
         - 0.0.0.0/0
-        port: 80
+        port: 443
     # Values required by this blueprint without defaults:
     #   region: "example-region"
     #   vpcId:  "example-vpc"
@@ -23,6 +23,7 @@ spec:
     #   - "example-subnet2"
     #   - "example-subnet3"
     #   upstreamSecurityGroup: "example-cluster-sg"
+    #   certificateArn: "example-cert-arn"
 
   # The following are templates used to 'implement' a 'parent' Gateway
   gatewayTemplate:
@@ -43,7 +44,14 @@ spec:
         spec:
           gatewayClassName: istio
           listeners:
-            {{- toYaml .Gateway.spec.listeners | nindent 6 }}
+          {{- range .Gateway.spec.listeners }}
+          - name: {{ .name }}
+            port: 80
+            protocol: HTTP
+            {{ if get . "hostname" }}
+            hostname: {{ .hostname | quote }}
+            {{ end -}}
+          {{- end }}
       LB: |
         apiVersion: elbv2.aws.upbound.io/v1beta1
         kind: LB
@@ -57,6 +65,7 @@ spec:
           forProvider:
             name: gw-{{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
             region: {{ .Values.region }}
+            internal: {{ .Values.internal }}
             securityGroupSelector:
               matchLabels:
                 tv2.dk/gw: {{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
@@ -100,8 +109,9 @@ spec:
             name: admin
           forProvider:
             region: {{ .Values.region }}
-            port: 80
-            protocol: HTTP
+            port: 443
+            protocol: HTTPS
+            certificateArn: {{ .Values.certificateArn }}
             defaultAction:
             - targetGroupArnSelector:
                 matchLabels:
@@ -148,6 +158,7 @@ spec:
           providerConfigRef:
             name: admin
           forProvider:
+            description: "Traffic towards Istio ingress gateway"
             cidrBlocks:
               - 0.0.0.0/0
             fromPort: 80
@@ -191,6 +202,7 @@ spec:
           providerConfigRef:
             name: admin
           forProvider:
+            description: "External traffic towards ALB"
             cidrBlocks:
               {{ range .Values.ingressAcls.cidrs -}}
               - {{ . }}

--- a/test-data/gatewayclassconfig-aws-alb-crossplane-dev-env.yaml
+++ b/test-data/gatewayclassconfig-aws-alb-crossplane-dev-env.yaml
@@ -12,6 +12,7 @@ spec:
     - subnet-0844755379de6d6f8
     - subnet-0e6f13b058d3c3729
     upstreamSecurityGroup: sg-0c5b5ae07d31da906
+    internal: false
   targetRef:
     group: gateway.networking.k8s.io
     kind: GatewayClass
@@ -31,6 +32,7 @@ spec:
     - subnet-094508a77cf895ec9
     - subnet-099f1b955e66e1a4a
     upstreamSecurityGroup: sg-0c5b5ae07d31da906
+    internal: true
   targetRef:
     group: gateway.networking.k8s.io
     kind: GatewayClass


### PR DESCRIPTION
This PR contains scripts and artifacts for demonstrating the gateway-controller.

The two `foo-namespaces.yaml` and `foo-gateway.yaml` are modified from the standard getting-started guide in that istio sidecar injection is enabled (this was not necessary with the getting-started guide istio installation) and that a aws/crossplane gateway class is used instead of `contour-istio`