### PR TITLE
Use Helm chart for getting started guide

### DIFF
--- a/Makefile.local
+++ b/Makefile.local
@@ -183,13 +183,9 @@ setup-getting-started-controller:
 
 .PHONY: setup-getting-started-controller-helm
 setup-getting-started-controller-helm:
-	# FIXME, REMOVE THESE, START
-	make build
-	make docker-build
-	make cluster-load-controller-image
-	# FIXME, REMOVE THESE, END
-	helm upgrade -i gateway-controller  charts/gateway-controller --values charts/gateway-controller/ci/gatewayclassblueprint-contour-istio.yaml --set controllerManager.manager.image.pullPolicy=Never -n gateway-controller-system --create-namespace
-	kubectl apply -f blueprints/gatewayclassblueprint-contour-istio-cert.yaml -f blueprints/gatewayclass-contour-istio-cert.yaml
+	helm repo add tv2-oss https://tv2-oss.github.io/gateway-controller
+	helm upgrade -i gateway-controller tv2-oss/gateway-controller --values charts/gateway-controller/ci/gatewayclassblueprint-contour-istio-values.yaml -n gateway-controller-system --create-namespace
+	kubectl apply -f test-data/gatewayclass-contour-istio-cert.yaml
 
 .PHONY: setup-getting-started-usecase
 setup-getting-started-usecase:

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -64,7 +64,7 @@ by the following sections.
 Deploying the controller using Helm can be sone as follows
 ```
 helm repo add tv2-oss https://tv2-oss.github.io/gateway-controller
-helm upgrade -i gateway-controller tv2-oss/gateway-controller --create-namespace
+helm upgrade -i gateway-controller tv2-oss/gateway-controller -n gateway-controller-system --create-namespace
 ```
 
 ### Deploy from Local-build and YAML Artifacts (recommended for end-to-end tests)

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -49,6 +49,11 @@ make setup-external-dns-test
 make deploy-cert-manager
 ```
 
+Alternatively the following make target wraps all of above commands:
+```
+make setup-getting-started-cluster
+```
+
 ## Deploy gateway-controller
 
 There are three alternative ways to deploy the controller as described
@@ -56,7 +61,11 @@ by the following sections.
 
 ### Deploy with Helm (recommended)
 
-TODO: We do not yet have a Helm chart
+Deploying the controller using Helm can be sone as follows
+```
+helm repo add tv2-oss https://tv2-oss.github.io/gateway-controller
+helm upgrade -i gateway-controller tv2-oss/gateway-controller --create-namespace
+```
 
 ### Deploy from Local-build and YAML Artifacts (recommended for end-to-end tests)
 


### PR DESCRIPTION
Add description to Getting Started guide for how to deploy using Helm chart and update the getting-started make target to use the Helm chart.