### PR TITLE
Change sprig funcmap to text template

### DIFF
--- a/controllers/templating.go
+++ b/controllers/templating.go
@@ -110,7 +110,7 @@ func parseSingleTemplate(tmplKey, tmpl string) (*template.Template, error) {
 	var funcs = template.FuncMap{
 		"toYaml": helperToYaml,
 	}
-	return template.New(tmplKey).Option("missingkey=error").Funcs(sprig.FuncMap()).Funcs(funcs).Parse(tmpl)
+	return template.New(tmplKey).Option("missingkey=error").Funcs(sprig.TxtFuncMap()).Funcs(funcs).Parse(tmpl)
 }
 
 // Initialize TemplateResource slice by parsing templates


### PR DESCRIPTION
`FuncMap` returns a `html/template`, but we use `text/template` and can get the following error:

```
controllers/templating.go:113:64: cannot use sprig.FuncMap() (value of type "html/template".FuncMap) as type "text/template".FuncMap in argument to template.New(tmplKey).Option("missingkey=error").Funcs
```